### PR TITLE
Remove ARG preceeding FROM in multistage Dockerfile because Quay build failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG HELM_VERSION=v2.14.1
-ARG KUBECTL_VERSION=v1.15.0
-FROM lachlanevenson/k8s-helm:${HELM_VERSION}
-FROM lachlanevenson/k8s-kubectl:${KUBECTL_VERSION}
+# Update versions as needed.
+FROM lachlanevenson/k8s-helm:v2.14.1
+FROM lachlanevenson/k8s-kubectl:v1.15.0
 
 # We build our own base awscli alpine image becase there is not yet an official
 # aws/aws-cli Alpine Docker image or stable Alpine package.


### PR DESCRIPTION
Quay error:
> Could not find or parse Dockerfile: First line in Dockerfile isn't FROM

This is [fine for docker build](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact), but since we're using Quay remove them for now.